### PR TITLE
Fixing 404 error that is caused when page refreshes

### DIFF
--- a/src/pages/singleEmployee/index.js
+++ b/src/pages/singleEmployee/index.js
@@ -31,6 +31,10 @@ export default function SingleEmployee() {
     navigate(`/FrontEndFinalProjectWebDev/task/${id}`);
   };
 
+  const handleGoEmployeePage = (id) => {
+    navigate(`/FrontEndFinalProjectWebDev/employee/${id}`);
+  };
+
   const refreshEmployees = async () => {
     const allEmployees = await EmployeeAPI.getAllEmployees();
     setEmployees(allEmployees);
@@ -65,7 +69,7 @@ export default function SingleEmployee() {
                 await EmployeeAPI.deleteEmployee(employee.id);
                 refreshEmployees(employee.id);
                 refreshOneEmployee(employee.id);
-                window.location.reload(false);
+                navigate(`/FrontEndFinalProjectWebDev/employees`);
               }}
             >
               Delete User
@@ -93,7 +97,7 @@ export default function SingleEmployee() {
                       onClick={async () => {
                         await TaskAPI.deleteTask(task.id);
                         refreshTasks();
-                        window.location.reload(false);
+                        handleGoEmployeePage(employee.id)
                       }}
                     >
                       Delete Task
@@ -102,7 +106,7 @@ export default function SingleEmployee() {
                       onClick={async () => {
                         await TaskAPI.unassignTask(task.id);
                         refreshTasks();
-                        window.location.reload(false);
+                        handleGoEmployeePage(employee.id)
                       }}
                     >
                       Unassign Task

--- a/src/pages/singleTask/index.js
+++ b/src/pages/singleTask/index.js
@@ -20,6 +20,10 @@ export default function SingleTask() {
     navigate(`/FrontEndFinalProjectWebDev/employee/${id}`);
   };
 
+  const handleGoTaskPage = (id) => {
+    navigate(`/FrontEndFinalProjectWebDev/task/${id}`);
+  };
+
   const getSingleTask = async (id) => {
     const foundTask = await TaskAPI.getSingleTask(id);
     setTask(foundTask);
@@ -55,7 +59,7 @@ export default function SingleTask() {
                 await TaskAPI.deleteTask(task.id);
                 refreshTasks();
                 getSingleTask(task.id);
-                window.location.reload(false);
+                navigate(`/FrontEndFinalProjectWebDev/tasks`);
               }}
             >
               Delete
@@ -65,7 +69,6 @@ export default function SingleTask() {
                 await TaskAPI.unassignTask(task.id);
                 refreshTasks();
                 getSingleTask(task.id);
-                window.location.reload(false);
               }}
             >
               Unassign


### PR DESCRIPTION
tried to fix a bug by having page refresh, causes 404 error in pages as there apparently is some compatibility issues between pages and react (when the app has multiple pages).
Still need a fix for the unassign button for tasks that does not remove EmplID number from taskcard.